### PR TITLE
Batch signatures are not LTV-enabled

### DIFF
--- a/AIS/ais.py
+++ b/AIS/ais.py
@@ -123,8 +123,8 @@ class AIS(object):
                     "SignatureType": "urn:ietf:rfc:3369",
                     "AdditionalProfile":
                     "http://ais.swisscom.ch/1.0/profiles/batchprocessing",
-                    # "AddTimestamp": {"@Type": "urn:ietf:rfc:3161"},
-                    # "sc.AddRevocationInformation": {"@Type": "BOTH"},
+                    "AddTimestamp": {"@Type": "urn:ietf:rfc:3161"},
+                    "sc.AddRevocationInformation": {"@Type": "BOTH"},
                 },
                 "InputDocuments": payload_documents
             }


### PR DESCRIPTION
Not sure why those 2 lines where commented out... 

I tested locally with this patch and things seem to work against the production AIS webservice