### PR TITLE
Stores the Last Issued Request Id

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: python
 python: 3.5
 
 env:
+  - TOXENV=py37
+  - TOXENV=py36
   - TOXENV=py35
   - TOXENV=py34
   - TOXENV=py27

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,6 @@ language: python
 matrix:
   include:
     - language: python
-      python: "3.7"
-      env: TOXENV=py37
-
-      # currently the only way to use Python 3.7 with travis
-      # https://github.com/travis-ci/travis-ci/issues/9069#issuecomment-425720905
-      sudo: required
-      dist: xenial
-
-    - language: python
       python: "3.6"
       env: TOXENV=py36
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,43 @@
 language: python
 
-python: 3.5
+matrix:
+  include:
+    - language: python
+      python: "3.7"
+      env: TOXENV=py37
 
-env:
-  - TOXENV=py37
-  - TOXENV=py36
-  - TOXENV=py35
-  - TOXENV=py34
-  - TOXENV=py27
-  - TOXENV=pypy
-  - TOXENV=lint
-  - TOXENV=readme
+      # currently the only way to use Python 3.7 with travis
+      # https://github.com/travis-ci/travis-ci/issues/9069#issuecomment-425720905
+      sudo: required
+      dist: xenial
+
+    - language: python
+      python: "3.6"
+      env: TOXENV=py36
+
+    - language: python
+      python: "3.5"
+      env: TOXENV=py35
+
+    - language: python
+      python: "3.4"
+      env: TOXENV=py34
+
+    - language: python
+      python: "2.7"
+      env: TOXENV=py27
+
+    - language: python
+      python: "pypy"
+      env: TOXENV=pypy
+
+    - language: python
+      python: "3.5"
+      env: TOXENV=lint
+
+    - language: python
+      python: "3.5"
+      env: TOXENV=readme
 
 before_script:
   - pip install tox

--- a/AIS/ais.py
+++ b/AIS/ais.py
@@ -31,10 +31,11 @@ class AIS(object):
         self.cert_key = cert_key
 
         self.byte_range = None
+        self.last_request_id = None
 
-    @staticmethod
-    def _request_id():
-        return uuid.uuid4().hex
+    def _request_id(self):
+        request_id = self.last_request_id = uuid.uuid4().hex
+        return request_id
 
     def post(self, payload):
         """ Do the post request for this payload and return the signature part

--- a/tests/test_ais.py
+++ b/tests/test_ais.py
@@ -22,26 +22,39 @@ class TestAIS(BaseCase):
         self.assertEqual('alice_secret', alice_instance.key_static)
 
     def test_sign_single_prepared_pdf(self):
+        self.assertIsNone(self.instance.last_request_id)
+
         pdf = PDF(fixture_path('prepared.pdf'), prepared=True)
         with my_vcr.use_cassette('sign_prepared_pdf'):
             self.instance.sign_one_pdf(pdf)
+
+        self.assertIsNotNone(self.instance.last_request_id)
 
         # TODO find a way to check the signature programmatically
         # Checked manually with Adobe Acrobat Reader DC for now
 
     def test_sign_single_unprepared_pdf(self):
+        self.assertIsNone(self.instance.last_request_id)
+
         pdf = PDF(fixture_path('one.pdf'))
         with my_vcr.use_cassette('sign_unprepared_pdf'):
             self.instance.sign_one_pdf(pdf)
+
+        self.assertIsNotNone(self.instance.last_request_id)
+
         # TODO check the signature
 
     def test_sign_batch(self):
+        self.assertIsNone(self.instance.last_request_id)
+
         pdfs = [PDF(fixture_path(filename))
                 for filename in ["one.pdf", "two.pdf", "three.pdf"]]
         with my_vcr.use_cassette('sign_batch'):
             self.instance.sign_batch(pdfs)
         from pprint import pprint as pp
         pp([p.out_filename for p in pdfs])
+
+        self.assertIsNotNone(self.instance.last_request_id)
 
         # TODO check the signature
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,pypy,lint
+envlist = py27,py34,py35,py36,py37,pypy,lint
 
 [testenv]
 passenv = AIS_CUSTOMER AIS_KEY_STATIC AIS_CERT_FILE AIS_CERT_KEY AIS_SSL_CA


### PR DESCRIPTION
As discussed in #7. This PR ensures that the last created request id can be retrieved later. Additionally it adds Python 3.6/3.7 to the test matrix. The last part is not necessary, but I didn't see a reason why not to updated it at the same time.

Cheers, Denis